### PR TITLE
Don’t distinguish between BSD and non-BSD manuals.

### DIFF
--- a/checknr/Makefile.mk
+++ b/checknr/Makefile.mk
@@ -13,7 +13,7 @@ checknr: $(OBJ)
 install:
 	$(INSTALL) -c checknr $(ROOT)$(BINDIR)/checknr
 	$(STRIP) $(ROOT)$(BINDIR)/checknr
-	$(INSTALL) -c -m 644 checknr.1b $(ROOT)$(MANDIR)/man1b/checknr.1b
+	$(INSTALL) -c -m 644 checknr.1 $(ROOT)$(MANDIR)/man1/checknr.1
 
 clean:
 	rm -f $(OBJ) checknr core log *~

--- a/checknr/checknr.1
+++ b/checknr/checknr.1
@@ -42,15 +42,15 @@
 .\"
 .\" Sccsid @(#)checknr.1b	1.2 (gritter) 11/6/05
 .\"
-.TH CHECKNR 1B "11/6/05" "Heirloom Documentation Tools" "BSD System Compatibility"
+.TH CHECKNR 1 "11/6/05" "Heirloom Documentation Tools" "BSD System Compatibility"
 .UC 4
 .SH NAME
-checknr \- (BSD) check nroff/troff files
+checknr \- check nroff/troff files
 .SH SYNOPSIS
 .HP
 .ad l
 .nh
-\fB/usr/ucb/checknr\fR
+\fBchecknr\fR
 [\fB\-fs\fR]
 [\fB\-a.\fIx1\fB.\fIy1\fB.\fIx2\fB.\fIy2\fB.\fR\ ...\ \fB.\fIxn\fB.\fIyn\fR]
 [\fB\-c.\fIx1\fB.\fIx2\fB.\fIx3\fR\ ...\ \fB.\fIxn\fR]
@@ -61,9 +61,9 @@ checknr \- (BSD) check nroff/troff files
 .SH DESCRIPTION
 .I Checknr
 checks a list of
-.IR nroff (1B)
+.IR nroff (1)
 or
-.IR troff (1B)
+.IR troff (1)
 input files for certain kinds of errors
 involving mismatched opening and closing delimiters
 and unknown commands.
@@ -81,9 +81,9 @@ the .TS and .TE macros which must always come in pairs.
 .PP
 .I Checknr
 knows about the
-.IR ms (7B)
+.IR ms (7)
 and
-.IR me (7B)
+.IR me (7)
 macro packages.
 .PP
 Additional pairs of macros can be added to the list using the
@@ -131,7 +131,7 @@ Since it is probably better to use the \efP and \es0 forms anyway,
 you should think of this as a contribution to your document
 preparation style.
 .SH SEE\ ALSO
-nroff(1B), troff(1B), checkeq(1B), ms(7B), me(7B)
+nroff(1), troff(1), checkeq(1), ms(7), me(7)
 .SH DIAGNOSTICS
 Complaints about unmatched delimiters.
 .br

--- a/eqn/checkeq.d/Makefile.mk
+++ b/eqn/checkeq.d/Makefile.mk
@@ -14,8 +14,8 @@ checkeq: $(OBJ)
 install:
 	$(INSTALL) -c checkeq $(ROOT)$(BINDIR)/checkeq
 	$(STRIP) $(ROOT)$(BINDIR)/checkeq
-	rm -f $(ROOT)$(MANDIR)/man1b/checkeq.1b
-	ln -s eqn.1b $(ROOT)$(MANDIR)/man1b/checkeq.1b
+	rm -f $(ROOT)$(MANDIR)/man1/checkeq.1
+	ln -s eqn.1 $(ROOT)$(MANDIR)/man1/checkeq.1
 
 clean:
 	rm -f $(OBJ) checkeq core log *~

--- a/eqn/eqn.d/Makefile.mk
+++ b/eqn/eqn.d/Makefile.mk
@@ -23,10 +23,10 @@ install:
 	test -d $(ROOT)$(BINDIR) || mkdir -p $(ROOT)$(BINDIR)
 	$(INSTALL) -c eqn $(ROOT)$(BINDIR)/eqn
 	$(STRIP) $(ROOT)$(BINDIR)/eqn
-	test -d $(ROOT)$(MANDIR)/man1b || mkdir -p $(ROOT)$(MANDIR)/man1b
-	test -d $(ROOT)$(MANDIR)/man7b || mkdir -p $(ROOT)$(MANDIR)/man7b
-	$(INSTALL) -c -m 644 eqn.1b $(ROOT)$(MANDIR)/man1b/eqn.1b
-	$(INSTALL) -c -m 644 eqnchar.7b $(ROOT)$(MANDIR)/man7b/eqnchar.7b
+	test -d $(ROOT)$(MANDIR)/man1 || mkdir -p $(ROOT)$(MANDIR)/man1
+	test -d $(ROOT)$(MANDIR)/man7 || mkdir -p $(ROOT)$(MANDIR)/man7
+	$(INSTALL) -c -m 644 eqn.1 $(ROOT)$(MANDIR)/man1/eqn.1
+	$(INSTALL) -c -m 644 eqnchar.7 $(ROOT)$(MANDIR)/man7/eqnchar.7
 
 clean:
 	rm -f $(OBJ) eqn e.c y.tab.* core log *~

--- a/eqn/eqn.d/eqn.1
+++ b/eqn/eqn.d/eqn.1
@@ -32,26 +32,26 @@
 .\" WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 .\" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.TH EQN 1B "12/12/05" "Heirloom Documentation Tools" "BSD System Compatibility"
+.TH EQN 1 "12/12/05" "Heirloom Documentation Tools" "BSD System Compatibility"
 .EQ
 delim $$
 .EN
 .SH NAME
-eqn, neqn, checkeq \- (BSD) typeset mathematics
+eqn, neqn, checkeq \- typeset mathematics
 .SH SYNOPSIS
-\fB/usr/ucb/eqn\fR
+\fBeqn\fR
 [\fB\-d\fIxy\fR]
 [\fB\-f\fIn\fR]
 [\fB\-s\fIn\fR]
 [\fIfile\fR] ...
 .br
-\fB/usr/ucb/neqn\fR [\fIfile\fR] ...
+\fBneqn\fR [\fIfile\fR] ...
 .br
-\fB/usr/ucb/checkeq\fR
+\fBcheckeq\fR
 .SH DESCRIPTION
 .I Eqn
 is a
-troff(1B)
+troff(1)
 preprocessor
 for typesetting mathematics
 on a phototypesetter,
@@ -304,7 +304,7 @@ Greek letters are spelled out in the desired case, as in
 or
 .I GAMMA.
 Mathematical words like sin, cos, log are made Roman automatically.
-.IR Troff (1B)
+.IR Troff (1)
 four-character escapes like \e(bs (\(bs)
 can be used anywhere.
 Strings enclosed in double quotes "..."
@@ -316,7 +316,7 @@ with
 when all else fails.
 .SH "SEE ALSO"
 .PP
-troff(1B), tbl(1B), ms(7), eqnchar(7B)
+troff(1), tbl(1), ms(7), eqnchar(7)
 .br
 B. W. Kernighan and L. L. Cherry,
 .ul

--- a/eqn/eqn.d/eqnchar.7
+++ b/eqn/eqn.d/eqnchar.7
@@ -32,7 +32,7 @@
 .\" WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 .\" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.TH EQNCHAR 7B "12/9/05" "Heirloom Documentation Tools" "BSD System Compatibility"
+.TH EQNCHAR 7 "12/9/05" "Heirloom Documentation Tools" "BSD System Compatibility"
 .EQ
 tdefine ciplus % "\o'\(pl\(ci'" %
 ndefine ciplus % O+ %
@@ -129,14 +129,14 @@ eqnchar \- special character definitions for eqn
 .HP
 .ad l
 .nh
-.B /usr/ucb/eqn /usr/pub/eqnchar
+.B eqn /usr/pub/eqnchar
 .RB [ files ]
-.B | /usr/ucb/troff
+.B | troff
 .RB [ options ]
 .HP
-.B /usr/ucb/neqn /usr/pub/eqnchar
+.B neqn /usr/pub/eqnchar
 .RB [ files ]
-.B | /usr/ucb/nroff
+.B | nroff
 .RB [ options ]
 .br
 .hy 1
@@ -209,4 +209,4 @@ definitions for the following characters
 .SH FILES
 /usr/pub/eqnchar
 .SH SEE ALSO
-troff(1B), eqn(1B)
+troff(1), eqn(1)

--- a/eqn/neqn.d/Makefile.mk
+++ b/eqn/neqn.d/Makefile.mk
@@ -22,8 +22,8 @@ y.tab.h: e.c
 install:
 	$(INSTALL) -c neqn $(ROOT)$(BINDIR)/neqn
 	$(STRIP) $(ROOT)$(BINDIR)/neqn
-	rm -f $(ROOT)$(MANDIR)/man1b/neqn.1b
-	ln -s eqn.1b $(ROOT)$(MANDIR)/man1b/neqn.1b
+	rm -f $(ROOT)$(MANDIR)/man1/neqn.1
+	ln -s eqn.1 $(ROOT)$(MANDIR)/man1/neqn.1
 
 clean:
 	rm -f $(OBJ) neqn e.c y.tab.* core log *~

--- a/grap/grap.1
+++ b/grap/grap.1
@@ -13,7 +13,7 @@
 .SH NAME
 grap \- pic preprocessor for drawing graphs
 .SH SYNOPSIS
-\fB/usr/ucb/grap\fR [\fB\-SU\fR] [\fIfile\fR]
+\fBgrap\fR [\fB\-SU\fR] [\fIfile\fR]
 .SH DESCRIPTION
 .I Grap
 is a
@@ -421,7 +421,7 @@ definitions of standard plotting characters, e.g., bullet
 .\".B /sys/src/cmd/grap
 .SH "SEE ALSO"
 .IR pic (1), 
-.IR troff (1B)
+.IR troff (1)
 .br
 J. L. Bentley and B. W. Kernighan,
 ``GRAP\(emA Language for Typesetting Graphs'',

--- a/pic/pic.1
+++ b/pic/pic.1
@@ -25,11 +25,11 @@
 .SH NAME
 pic \- troff preprocessor for drawing pictures
 .SH SYNOPSIS
-\fB/usr/ucb/pic\fR [\fB\-SU\fR] [\fIfiles\fR]
+\fBpic\fR [\fB\-SU\fR] [\fIfiles\fR]
 .SH DESCRIPTION
 .I Pic
 is a
-.IR troff (1B)
+.IR troff (1)
 preprocessor for drawing figures on a typesetter.
 .I Pic
 code is contained between
@@ -359,7 +359,7 @@ reverts the effect of a previous
 .\".B /sys/src/cmd/pic
 .SH "SEE ALSO"
 .IR grap (1), 
-.IR troff (1B)
+.IR troff (1)
 .br
 B. W. Kernighan,
 ``PIC\(ema Graphics Language for Typesetting'',

--- a/picpack/picpack.1
+++ b/picpack/picpack.1
@@ -13,7 +13,7 @@
 .SH NAME
 picpack \- PostScript picture packing preprocessor
 .SH SYNOPSIS
-\fB/usr/ucb/picpack\fR [\fB\-k\fI\ list\fR] [\fB\-q\fR] [\fIfile\fR] ...
+\fBpicpack\fR [\fB\-k\fI\ list\fR] [\fB\-q\fR] [\fIfile\fR] ...
 .SH DESCRIPTION
 .B picpack
 copies
@@ -133,4 +133,4 @@ is only guaranteed to work with
 .BR dpost .
 .SH SEE ALSO
 .BR dpost (1),
-.BR troff (1B)
+.BR troff (1)

--- a/ptx/ptx.1
+++ b/ptx/ptx.1
@@ -39,7 +39,7 @@ ptx \- permuted index
 .HP
 .ad l
 .nh
-\fB/usr/ucb/ptx\fR
+\fBptx\fR
 [\fB\-ftr\fR]
 [\fB\-w\fI\ n\fR]
 [\fB\-g\fI\ n\fR]
@@ -73,7 +73,7 @@ produces output in the form:
 where .xx may be an
 .I nroff
 or
-.IR troff (1B)
+.IR troff (1)
 macro
 for user-defined formatting.
 Once choice for this macro is supplied in the `\-mptx'

--- a/refer/Makefile.mk
+++ b/refer/Makefile.mk
@@ -73,12 +73,12 @@ install: all
 	$(INSTALL) -c papers/Rv7man $(ROOT)$(REFDIR)/papers/Rv7man
 	$(INSTALL) -c papers/runinv $(ROOT)$(REFDIR)/papers/runinv
 	cd $(ROOT)$(REFDIR)/papers && PATH=$(ROOT)$(REFDIR):$$PATH ./runinv
-	for i in addbib.1b lookbib.1b refer.1b roffbib.1b sortbib.1b; \
+	for i in addbib.1 lookbib.1 refer.1 roffbib.1 sortbib.1; \
 	do \
-		$(INSTALL) -c -m 644 $$i $(ROOT)$(MANDIR)/man1b/$$i || exit; \
+		$(INSTALL) -c -m 644 $$i $(ROOT)$(MANDIR)/man1/$$i || exit; \
 	done
-	rm -f $(ROOT)$(MANDIR)/man1b/indxbib.1b
-	ln -s lookbib.1b $(ROOT)$(MANDIR)/man1b/indxbib.1b
+	rm -f $(ROOT)$(MANDIR)/man1/indxbib.1
+	ln -s lookbib.1 $(ROOT)$(MANDIR)/man1/indxbib.1
 
 clean:
 	rm -f $(ROBJ) refer $(AOBJ) addbib $(LOBJ) lookbib \

--- a/refer/addbib.1
+++ b/refer/addbib.1
@@ -67,76 +67,103 @@
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 .\" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.\" Sccsid @(#)sortbib.1b	1.4 (gritter) 12/12/05
+.\" Sccsid @(#)addbib.1b	1.4 (gritter) 12/12/05
 .\"
-.\"	from 4.3BSD-Tahoe sortbib.1	6.1 (Berkeley) 4/29/85
 .\"
-.\".TH SORTBIB 1 "April 29, 1985"
-.TH SORTBIB 1B "12/12/05" "Heirloom Documentation Tools" "BSD System Compatibility"
+.\"	from 4.3BSD-Tahoe addbib.1	6.1 (Berkeley) 4/29/85
+.\"
+.\".TH ADDBIB 1 "April 29, 1985"
+.TH ADDBIB 1 "12/12/05" "Heirloom Documentation Tools" "BSD System Compatibility"
 .UC 5
 .SH NAME
-sortbib \- (BSD) sort bibliographic database
+addbib \- create or extend bibliographic database
 .SH SYNOPSIS
-\fB/usr/ucb/sortbib\fR [\fB\-s\ \fIKEYS\fR] \fIdatabase\fR ...
+\fBaddbib\fR
+[\fB\-p\fI\ promptfile\fR] [\fB\-a\fR] \fIdatabase\fR
 .SH DESCRIPTION
-.I Sortbib
-sorts files of records containing
-.I refer
-key-letters by user-specified keys.
-Records may be separated by blank lines,
-or by \&.[ and \&.] delimiters,
-but the two styles may not be mixed together.
-This program reads through each
+When this program starts up, answering ``y''
+to the initial ``Instructions?'' prompt yields directions;
+typing ``n'' or \s-2RETURN\s0 skips them.
+.I Addbib
+then prompts for various bibliographic fields,
+reads responses from the terminal,
+and sends output records to a
+.I database.
+A null response (just \s-2RETURN\s0) means to leave out that field.
+A minus sign (\-) means to go back to the previous field.
+A trailing backslash allows a field to be continued on the next line.
+The repeating ``Continue?'' prompt allows the user
+either to resume by typing ``y'' or \s-2RETURN\s0,
+to quit the current session by typing ``n'' or ``q'',
+or to edit the
 .I database
-and pulls out key fields, which are sorted separately.
-The sorted key fields contain the file pointer,
-byte offset, and length of corresponding records.
-These records are delivered using disk seeks and reads, so
-.I sortbib
-may not be used in a pipeline to read standard input.
+with any system editor \fI(vi, ex, edit, ed).\fP
 .PP
-By default,
-.I sortbib
-alphabetizes by the first %A and the %D fields,
-which contain the senior author and date.
 The
-.B \-s
-option is used to specify new
-.IR \s-1KEYS\s0 .
-For instance,
-.BR \-s ATD
-will sort by author, title, and date,
-while
-.BR \-s A+D
-will sort by all authors, and date.
-Sort keys past the fourth are not meaningful.
-No more than 16 databases may be sorted together at one time.
-Records longer than 4096 characters will be truncated.
+.B \-a
+option suppresses prompting for an abstract;
+asking for an abstract is the default.
+Abstracts are ended with a \s-2CTRL\s0-d.
+The
+.B \-p
+option causes
+.I addbib
+to use a new prompting skeleton, defined in
+.I promptfile.
+This file should contain prompt strings, a tab,
+and the key-letters to be written to the
+.I database.
 .PP
-.I Sortbib
-sorts on the last word on the %A line,
-which is assumed to be the author's last name.
-A word in the final position, such as ``jr.'' or ``ed.'',
-will be ignored if the name beforehand ends with a comma.
-Authors with two-word last names or unusual constructions
-can be sorted correctly by using the
-.I nroff
-convention ``\e0'' in place of a blank.
-A %Q field is considered to be the same as %A,
-except sorting begins with the first, not the last, word.
-.I Sortbib
-sorts on the last word of the %D line, usually the year.
-It also ignores leading articles (like ``A'' or ``The'')
-when sorting by titles in the %T or %J fields;
-it will ignore articles of any modern European language.
-If a sort-significant field is absent from a record,
-.I sortbib
-places that record before other records containing that field.
+The most common key-letters and their meanings are given below.
+.I Addbib
+insulates you from these key-letters,
+since it gives you prompts in English,
+but if you edit the bibliography file later on,
+you will need to know this information.
+.sp
+.nf
+	%A	Author's name
+	%B	Book containing article referenced
+	%C	City (place of publication)
+	%D	Date of publication
+	%E	Editor of book containing article referenced
+	%F	Footnote number or label (supplied by \fIrefer\fP\|)
+	%G	Government order number
+	%H	Header commentary, printed before reference
+	%I	Issuer (publisher)
+	%J	Journal containing article
+	%K	Keywords to use in locating reference
+	%L	Label field used by \fB\-k\fP option of \fIrefer\fP
+	%M	Bell Labs Memorandum (undefined)
+	%N	Number within volume
+	%O	Other commentary, printed at end of reference
+	%P	Page number(s)
+	%Q	Corporate or Foreign Author (unreversed)
+	%R	Report, paper, or thesis (unpublished)
+	%S	Series title
+	%T	Title of article or book
+	%V	Volume number
+	%X	Abstract \(em used by \fIroffbib\fP, not by \fIrefer\fP
+	%Y,Z	ignored by \fIrefer\fP
+.fi
+.sp
+Except for `A', each field should be given just once.
+Only relevant fields should be supplied.
+An example is:
+.sp
+.nf
+	%A	Bill Tuthill
+	%T	Refer \(em A Bibliography System
+	%I	Computing Services
+	%C	Berkeley
+	%D	1982
+	%O	\s-1UNX\s0 4.3.5.
+.fi
+.sp
+.SH FILES
+.DT
+promptfile	optional file to define prompting
 .SH SEE ALSO
-refer(1B), addbib(1B), roffbib(1B), indxbib(1B), lookbib(1B)
+refer(1), sortbib(1), roffbib(1), indxbib(1), lookbib(1)
 .SH NOTES
-Records with missing author fields
-should probably be sorted by title.
-.PP
-Written by
-Greg Shenaut & Bill Tuthill.
+Written by Al Stangenberger & Bill Tuthill.

--- a/refer/lookbib.1
+++ b/refer/lookbib.1
@@ -67,105 +67,98 @@
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 .\" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.\" Sccsid @(#)roffbib.1b	1.4 (gritter) 12/12/05
+.\" Sccsid @(#)lookbib.1b	1.5 (gritter) 9/6/08
 .\"
+.\"	from 4.3BSD-Tahoe lookbib.1	6.1 (Berkeley) 4/29/85
 .\"
-.\"	from 4.3BSD-Tahoe roffbib.1	6.2 (Berkeley) 5/7/86
-.\"
-.\".TH ROFFBIB 1 "May 7, 1986"
-.TH ROFFBIB 1B "12/12/05" "Heirloom Documentation Tools" "BSD System Compatibility"
+.\".TH LOOKBIB 1 "April 29, 1985"
+.TH LOOKBIB 1 "9/6/08" "Heirloom Documentation Tools" "BSD System Compatibility"
 .UC 5
 .SH NAME
-roffbib \- (BSD) run off bibliographic database
+indxbib, lookbib \- build inverted index for a bibliography, find references in a bibliography
 .SH SYNOPSIS
-.HP
-.ad l
-.nh
-\fB/usr/ucb/roffbib\fR
-[\fB\-ehnorsxVQ\fR]
-[\fB\-T\fIterm\fR]
-[\fB\-m\fImac\fR]
-[\fIfile\ \fR...]
+\fBindxbib\fR \fIdatabase\fR ...
 .br
-.hy 1
-.ad b
+\fBlookbib\fR \fIdatabase\fR
 .SH DESCRIPTION
-.I Roffbib
-prints out all records in a bibliographic database,
-in bibliography format rather than as footnotes or endnotes.
-Generally it is used in conjunction with
-.IR sortbib :
-.LP
-.RS
-sortbib  database | roffbib
-.RE
-.LP
-.I Roffbib
-accepts most of the options understood by
-.IR nroff (1B),
-most importantly the
-.B \-T
-flag to specify terminal type.
-.PP
-If abstracts or comments are entered following the %X field key,
-.I roffbib
-will format them into paragraphs for an annotated bibliography.
-Several %X fields may be given if several
-annotation paragraphs are desired.
-The
-.B \-x
-flag will suppress the printing of these abstracts.
-.PP
-A user-defined set of macros
-may be specified after the
-.B \-m
-option.
-There should be a space between the
-.B \-m
-and the macro filename.
-This set of macros will replace the ones
-defined in /usr/ucblib/doctools/tmac/bib.
-The
-.B \-V
-flag will send output to the Versatec; the
-.B \-Q
-flag will queue output for the phototypesetter.
-.PP
-Four command-line registers control formatting style
-of the bibliography, much like the number registers of
-.IR ms (7B).
-The command-line argument
-.BR \-r N1
-will number
-the references starting at one (1).
-The flag
-.BR \-r V2
-will double space the biblio\%graphy,
-while
-.BR \-r V1
-will double space references
-but single space annotation paragraphs.
-The line length can be changed from the default 6.5 inches
-to 6 inches with the
-.BR \-r L6i
-argument,
-and the page offset can be set from the default of 0
-to one inch by specifying
-.BR \-r O1i
-(capital O, not zero).
-Note: with the
-.B \-V
+.I Indxbib
+makes an inverted index to the named
+.I databases
+(or files) for use by
+.IR lookbib (1)
 and
-.B \-Q
-flags
-the default page offset is already one inch.
+.IR refer (1).
+These files contain bibliographic references
+(or other kinds of information) separated by blank lines.
+.PP
+A bibliographic reference is a set of lines,
+constituting fields of bibliographic information.
+Each field starts on a line beginning with a ``%'',
+followed by a key-letter, then a blank,
+and finally the contents of the field,
+which may continue until the next line starting with ``%''.
+.PP
+.I Indxbib 
+is a shell script that calls
+/usr/ucblib/reftools/mkey and /usr/ucblib/reftools/inv.
+The first program,
+.I mkey,
+truncates words to 6 characters,
+and maps upper case to lower case.
+It also discards words shorter than 3 characters,
+words among the 100 most common English words,
+and numbers (dates) < 1900 or > 2000.
+These parameters can be changed; see page 4 of the
+.I Refer
+document by Mike Lesk.
+The second program,
+.I inv,
+creates an entry file (.ia),
+a posting file (.ib), and a tag file (.ic),
+all in the working directory.
+.PP
+.I Lookbib
+uses an inverted index made by
+.I indxbib
+to find sets of bibliographic references.
+It reads keywords typed after the ``>'' prompt on the terminal,
+and retrieves records containing all these keywords.
+If nothing matches, nothing is returned except another ``>'' prompt.
+.PP
+.I Lookbib
+will ask if you need instructions, and will print some brief information if
+you reply ``y''.
+.PP
+It is possible to search multiple databases,
+as long as they have a common index made by
+.I indxbib.
+In that case, only the first argument given to
+.I indxbib
+is specified to
+.I lookbib.
+.PP
+If
+.I lookbib
+does not find the index files (the .i[abc] files),
+it looks for a reference file with the same name as the argument,
+without the suffixes.
+It creates a file with a `.ig' suffix, suitable for use with
+.I fgrep.
+It then uses this fgrep file to find references.
+This method is simpler to use, but the .ig file is slower to use
+than the .i[abc] files, and does not allow the use of multiple reference files.
 .SH FILES
-.ta \w'/usr/ucblib/doctools/tmac/bib\0\0'u
-.nf
-/usr/ucblib/doctools/tmac/bib	file of macros used by \fInroff/troff\fP
-.fi
+.IR x .ia,
+.IR x .ib,
+.IR x .ic,
+where 
+.I x
+is the first argument, or if these are not present, then
+.IR x .ig,
+.IR x
 .SH SEE ALSO
-refer(1B), addbib(1B), sortbib(1B), indxbib(1B), lookbib(1B)
+refer(1), addbib(1), sortbib(1), roffbib(1), lookbib(1)
 .SH NOTES
-Users have to rewrite macros
-to create customized formats.
+Probably all dates should be indexed,
+since many disciplines refer to literature
+written in the 1800s or earlier.

--- a/refer/refer.1
+++ b/refer/refer.1
@@ -70,15 +70,15 @@
 .\"
 .\"
 .\".TH REFER 1 "May 12, 1986"
-.TH REFER 1B "12/12/05" "Heirloom Documentation Tools" "BSD System Compatibility"
+.TH REFER 1 "12/12/05" "Heirloom Documentation Tools" "BSD System Compatibility"
 .AT 3
 .SH NAME
-refer \- (BSD) find and insert literature references in documents
+refer \- find and insert literature references in documents
 .SH SYNOPSIS
 .HP
 .ad l
 .nh
-\fB/usr/ucb/refer\fR
+\fBrefer\fR
 [\fB\-abcenPS\fR]
 [\fB\-f\fIn\fR]
 [\fB\-k\fIx\fR]
@@ -95,7 +95,7 @@ refer \- (BSD) find and insert literature references in documents
 is a preprocessor for
 .I nroff
 or
-.IR troff (1B)
+.IR troff (1)
 that finds and formats references for footnotes or endnotes.
 It is also the base for a series of programs designed to
 index, search, sort, and print stand-alone bibliographies,
@@ -116,7 +116,7 @@ The reference data, from whatever source, are assigned to a set of
 .I troff
 strings.
 Macro packages such as
-.IR ms (7B)
+.IR ms (7)
 print the finished reference text from these strings.
 By default references are flagged by footnote numbers.
 .PP
@@ -256,7 +256,7 @@ Produce references in the Natural or Social Science format.
 To use your own references,
 put them in the format described below.
 They can be searched more rapidly by running
-.IR indxbib (1B)
+.IR indxbib (1)
 on them before using
 .I refer;
 failure to index results in a linear search.
@@ -291,7 +291,7 @@ is controlled by the macros specified for
 (for stand-alone bibliographies).
 For a list of the most common key-letters
 and their corresponding fields, see
-.IR addbib (1B).
+.IR addbib (1).
 An example of a
 .I refer
 entry is given below.
@@ -312,7 +312,7 @@ entry is given below.
 .br
 /usr/ucblib/reftools  	directory of companion programs
 .SH SEE ALSO
-addbib(1B), sortbib(1B), roffbib(1B), indxbib(1B), lookbib(1B)
+addbib(1), sortbib(1), roffbib(1), indxbib(1), lookbib(1)
 .SH NOTES
 Blank spaces at the end of lines in bibliography fields
 will cause the records to sort and reverse incorrectly.

--- a/refer/roffbib.1
+++ b/refer/roffbib.1
@@ -67,98 +67,105 @@
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 .\" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.\" Sccsid @(#)lookbib.1b	1.5 (gritter) 9/6/08
+.\" Sccsid @(#)roffbib.1b	1.4 (gritter) 12/12/05
 .\"
-.\"	from 4.3BSD-Tahoe lookbib.1	6.1 (Berkeley) 4/29/85
 .\"
-.\".TH LOOKBIB 1 "April 29, 1985"
-.TH LOOKBIB 1B "9/6/08" "Heirloom Documentation Tools" "BSD System Compatibility"
+.\"	from 4.3BSD-Tahoe roffbib.1	6.2 (Berkeley) 5/7/86
+.\"
+.\".TH ROFFBIB 1 "May 7, 1986"
+.TH ROFFBIB 1 "12/12/05" "Heirloom Documentation Tools" "BSD System Compatibility"
 .UC 5
 .SH NAME
-indxbib, lookbib \- (BSD) build inverted index for a bibliography, find references in a bibliography
+roffbib \- run off bibliographic database
 .SH SYNOPSIS
-\fB/usr/ucb/indxbib\fR \fIdatabase\fR ...
+.HP
+.ad l
+.nh
+\fBroffbib\fR
+[\fB\-ehnorsxVQ\fR]
+[\fB\-T\fIterm\fR]
+[\fB\-m\fImac\fR]
+[\fIfile\ \fR...]
 .br
-\fB/usr/ucb/lookbib\fR \fIdatabase\fR
+.hy 1
+.ad b
 .SH DESCRIPTION
-.I Indxbib
-makes an inverted index to the named
-.I databases
-(or files) for use by
-.IR lookbib (1B)
+.I Roffbib
+prints out all records in a bibliographic database,
+in bibliography format rather than as footnotes or endnotes.
+Generally it is used in conjunction with
+.IR sortbib :
+.LP
+.RS
+sortbib  database | roffbib
+.RE
+.LP
+.I Roffbib
+accepts most of the options understood by
+.IR nroff (1),
+most importantly the
+.B \-T
+flag to specify terminal type.
+.PP
+If abstracts or comments are entered following the %X field key,
+.I roffbib
+will format them into paragraphs for an annotated bibliography.
+Several %X fields may be given if several
+annotation paragraphs are desired.
+The
+.B \-x
+flag will suppress the printing of these abstracts.
+.PP
+A user-defined set of macros
+may be specified after the
+.B \-m
+option.
+There should be a space between the
+.B \-m
+and the macro filename.
+This set of macros will replace the ones
+defined in /usr/ucblib/doctools/tmac/bib.
+The
+.B \-V
+flag will send output to the Versatec; the
+.B \-Q
+flag will queue output for the phototypesetter.
+.PP
+Four command-line registers control formatting style
+of the bibliography, much like the number registers of
+.IR ms (7).
+The command-line argument
+.BR \-r N1
+will number
+the references starting at one (1).
+The flag
+.BR \-r V2
+will double space the biblio\%graphy,
+while
+.BR \-r V1
+will double space references
+but single space annotation paragraphs.
+The line length can be changed from the default 6.5 inches
+to 6 inches with the
+.BR \-r L6i
+argument,
+and the page offset can be set from the default of 0
+to one inch by specifying
+.BR \-r O1i
+(capital O, not zero).
+Note: with the
+.B \-V
 and
-.IR refer (1B).
-These files contain bibliographic references
-(or other kinds of information) separated by blank lines.
-.PP
-A bibliographic reference is a set of lines,
-constituting fields of bibliographic information.
-Each field starts on a line beginning with a ``%'',
-followed by a key-letter, then a blank,
-and finally the contents of the field,
-which may continue until the next line starting with ``%''.
-.PP
-.I Indxbib 
-is a shell script that calls
-/usr/ucblib/reftools/mkey and /usr/ucblib/reftools/inv.
-The first program,
-.I mkey,
-truncates words to 6 characters,
-and maps upper case to lower case.
-It also discards words shorter than 3 characters,
-words among the 100 most common English words,
-and numbers (dates) < 1900 or > 2000.
-These parameters can be changed; see page 4 of the
-.I Refer
-document by Mike Lesk.
-The second program,
-.I inv,
-creates an entry file (.ia),
-a posting file (.ib), and a tag file (.ic),
-all in the working directory.
-.PP
-.I Lookbib
-uses an inverted index made by
-.I indxbib
-to find sets of bibliographic references.
-It reads keywords typed after the ``>'' prompt on the terminal,
-and retrieves records containing all these keywords.
-If nothing matches, nothing is returned except another ``>'' prompt.
-.PP
-.I Lookbib
-will ask if you need instructions, and will print some brief information if
-you reply ``y''.
-.PP
-It is possible to search multiple databases,
-as long as they have a common index made by
-.I indxbib.
-In that case, only the first argument given to
-.I indxbib
-is specified to
-.I lookbib.
-.PP
-If
-.I lookbib
-does not find the index files (the .i[abc] files),
-it looks for a reference file with the same name as the argument,
-without the suffixes.
-It creates a file with a `.ig' suffix, suitable for use with
-.I fgrep.
-It then uses this fgrep file to find references.
-This method is simpler to use, but the .ig file is slower to use
-than the .i[abc] files, and does not allow the use of multiple reference files.
+.B \-Q
+flags
+the default page offset is already one inch.
 .SH FILES
-.IR x .ia,
-.IR x .ib,
-.IR x .ic,
-where 
-.I x
-is the first argument, or if these are not present, then
-.IR x .ig,
-.IR x
+.ta \w'/usr/ucblib/doctools/tmac/bib\0\0'u
+.nf
+/usr/ucblib/doctools/tmac/bib	file of macros used by \fInroff/troff\fP
+.fi
 .SH SEE ALSO
-refer(1B), addbib(1B), sortbib(1B), roffbib(1B), lookbib(1B)
+refer(1), addbib(1), sortbib(1), indxbib(1), lookbib(1)
 .SH NOTES
-Probably all dates should be indexed,
-since many disciplines refer to literature
-written in the 1800s or earlier.
+Users have to rewrite macros
+to create customized formats.

--- a/refer/sortbib.1
+++ b/refer/sortbib.1
@@ -67,103 +67,76 @@
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 .\" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.\" Sccsid @(#)addbib.1b	1.4 (gritter) 12/12/05
+.\" Sccsid @(#)sortbib.1b	1.4 (gritter) 12/12/05
 .\"
+.\"	from 4.3BSD-Tahoe sortbib.1	6.1 (Berkeley) 4/29/85
 .\"
-.\"	from 4.3BSD-Tahoe addbib.1	6.1 (Berkeley) 4/29/85
-.\"
-.\".TH ADDBIB 1 "April 29, 1985"
-.TH ADDBIB 1B "12/12/05" "Heirloom Documentation Tools" "BSD System Compatibility"
+.\".TH SORTBIB 1 "April 29, 1985"
+.TH SORTBIB 1 "12/12/05" "Heirloom Documentation Tools" "BSD System Compatibility"
 .UC 5
 .SH NAME
-addbib \- (BSD) create or extend bibliographic database
+sortbib \- sort bibliographic database
 .SH SYNOPSIS
-\fB/usr/ucb/addbib\fR
-[\fB\-p\fI\ promptfile\fR] [\fB\-a\fR] \fIdatabase\fR
+\fBsortbib\fR [\fB\-s\ \fIKEYS\fR] \fIdatabase\fR ...
 .SH DESCRIPTION
-When this program starts up, answering ``y''
-to the initial ``Instructions?'' prompt yields directions;
-typing ``n'' or \s-2RETURN\s0 skips them.
-.I Addbib
-then prompts for various bibliographic fields,
-reads responses from the terminal,
-and sends output records to a
-.I database.
-A null response (just \s-2RETURN\s0) means to leave out that field.
-A minus sign (\-) means to go back to the previous field.
-A trailing backslash allows a field to be continued on the next line.
-The repeating ``Continue?'' prompt allows the user
-either to resume by typing ``y'' or \s-2RETURN\s0,
-to quit the current session by typing ``n'' or ``q'',
-or to edit the
+.I Sortbib
+sorts files of records containing
+.I refer
+key-letters by user-specified keys.
+Records may be separated by blank lines,
+or by \&.[ and \&.] delimiters,
+but the two styles may not be mixed together.
+This program reads through each
 .I database
-with any system editor \fI(vi, ex, edit, ed).\fP
+and pulls out key fields, which are sorted separately.
+The sorted key fields contain the file pointer,
+byte offset, and length of corresponding records.
+These records are delivered using disk seeks and reads, so
+.I sortbib
+may not be used in a pipeline to read standard input.
 .PP
+By default,
+.I sortbib
+alphabetizes by the first %A and the %D fields,
+which contain the senior author and date.
 The
-.B \-a
-option suppresses prompting for an abstract;
-asking for an abstract is the default.
-Abstracts are ended with a \s-2CTRL\s0-d.
-The
-.B \-p
-option causes
-.I addbib
-to use a new prompting skeleton, defined in
-.I promptfile.
-This file should contain prompt strings, a tab,
-and the key-letters to be written to the
-.I database.
+.B \-s
+option is used to specify new
+.IR \s-1KEYS\s0 .
+For instance,
+.BR \-s ATD
+will sort by author, title, and date,
+while
+.BR \-s A+D
+will sort by all authors, and date.
+Sort keys past the fourth are not meaningful.
+No more than 16 databases may be sorted together at one time.
+Records longer than 4096 characters will be truncated.
 .PP
-The most common key-letters and their meanings are given below.
-.I Addbib
-insulates you from these key-letters,
-since it gives you prompts in English,
-but if you edit the bibliography file later on,
-you will need to know this information.
-.sp
-.nf
-	%A	Author's name
-	%B	Book containing article referenced
-	%C	City (place of publication)
-	%D	Date of publication
-	%E	Editor of book containing article referenced
-	%F	Footnote number or label (supplied by \fIrefer\fP\|)
-	%G	Government order number
-	%H	Header commentary, printed before reference
-	%I	Issuer (publisher)
-	%J	Journal containing article
-	%K	Keywords to use in locating reference
-	%L	Label field used by \fB\-k\fP option of \fIrefer\fP
-	%M	Bell Labs Memorandum (undefined)
-	%N	Number within volume
-	%O	Other commentary, printed at end of reference
-	%P	Page number(s)
-	%Q	Corporate or Foreign Author (unreversed)
-	%R	Report, paper, or thesis (unpublished)
-	%S	Series title
-	%T	Title of article or book
-	%V	Volume number
-	%X	Abstract \(em used by \fIroffbib\fP, not by \fIrefer\fP
-	%Y,Z	ignored by \fIrefer\fP
-.fi
-.sp
-Except for `A', each field should be given just once.
-Only relevant fields should be supplied.
-An example is:
-.sp
-.nf
-	%A	Bill Tuthill
-	%T	Refer \(em A Bibliography System
-	%I	Computing Services
-	%C	Berkeley
-	%D	1982
-	%O	\s-1UNX\s0 4.3.5.
-.fi
-.sp
-.SH FILES
-.DT
-promptfile	optional file to define prompting
+.I Sortbib
+sorts on the last word on the %A line,
+which is assumed to be the author's last name.
+A word in the final position, such as ``jr.'' or ``ed.'',
+will be ignored if the name beforehand ends with a comma.
+Authors with two-word last names or unusual constructions
+can be sorted correctly by using the
+.I nroff
+convention ``\e0'' in place of a blank.
+A %Q field is considered to be the same as %A,
+except sorting begins with the first, not the last, word.
+.I Sortbib
+sorts on the last word of the %D line, usually the year.
+It also ignores leading articles (like ``A'' or ``The'')
+when sorting by titles in the %T or %J fields;
+it will ignore articles of any modern European language.
+If a sort-significant field is absent from a record,
+.I sortbib
+places that record before other records containing that field.
 .SH SEE ALSO
-refer(1B), sortbib(1B), roffbib(1B), indxbib(1B), lookbib(1B)
+refer(1), addbib(1), roffbib(1), indxbib(1), lookbib(1)
 .SH NOTES
-Written by Al Stangenberger & Bill Tuthill.
+Records with missing author fields
+should probably be sorted by title.
+.PP
+Written by
+Greg Shenaut & Bill Tuthill.

--- a/soelim/Makefile.mk
+++ b/soelim/Makefile.mk
@@ -13,7 +13,7 @@ soelim: $(OBJ)
 install:
 	$(INSTALL) -c soelim $(ROOT)$(BINDIR)/soelim
 	$(STRIP) $(ROOT)$(BINDIR)/soelim
-	$(INSTALL) -c -m 644 soelim.1b $(ROOT)$(MANDIR)/man1b/soelim.1b
+	$(INSTALL) -c -m 644 soelim.1 $(ROOT)$(MANDIR)/man1/soelim.1
 
 clean:
 	rm -f $(OBJ) soelim core log *~

--- a/soelim/soelim.1
+++ b/soelim/soelim.1
@@ -31,11 +31,11 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.TH SOELIM 1B "8/13/05" "Heirloom Documentation Tools" "BSD System Compatibility"
+.TH SOELIM 1 "8/13/05" "Heirloom Documentation Tools" "BSD System Compatibility"
 .SH NAME
-soelim \- (BSD) eliminate \&.so's from nroff input
+soelim \- eliminate \&.so's from nroff input
 .SH SYNOPSIS
-\fB/usr/ucb/soelim\fR [\fIfile\fR] ...
+\fBsoelim\fR [\fIfile\fR] ...
 .SH DESCRIPTION
 .I Soelim
 reads the specified files or the standard input and performs the textual

--- a/tbl/Makefile.mk
+++ b/tbl/Makefile.mk
@@ -14,7 +14,7 @@ tbl: $(OBJ)
 install:
 	$(INSTALL) -c tbl $(ROOT)$(BINDIR)/tbl
 	$(STRIP) $(ROOT)$(BINDIR)/tbl
-	$(INSTALL) -c -m 644 tbl.1b $(ROOT)$(MANDIR)/man1b/tbl.1b
+	$(INSTALL) -c -m 644 tbl.1 $(ROOT)$(MANDIR)/man1/tbl.1
 
 clean:
 	rm -f $(OBJ) tbl core log *~

--- a/tbl/tbl.1
+++ b/tbl/tbl.1
@@ -32,11 +32,11 @@
 .\" WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 .\" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.TH TBL 1B "9/9/06" "Heirloom Documentation Tools" "BSD System Compatibility"
+.TH TBL 1 "9/9/06" "Heirloom Documentation Tools" "BSD System Compatibility"
 .SH NAME
-tbl \- (BSD) format tables for nroff or troff
+tbl \- format tables for nroff or troff
 .SH SYNOPSIS
-\fB/usr/ucb/tbl\fR
+\fBtbl\fR
 [\fB\-g\fR]
 [\fB\-me\fR|\fB\-mm\fR|\fB\-ms\fR]
 [\fB\-TX\fR]
@@ -131,7 +131,7 @@ option causes
 .I tbl
 not to produce fractional line motions.
 .SH SEE ALSO
-troff(1B), eqn(1B)
+troff(1), eqn(1)
 .br
 M. E. Lesk,
 .I TBL.

--- a/troff/nroff.d/Makefile.mk
+++ b/troff/nroff.d/Makefile.mk
@@ -21,7 +21,7 @@ nroff: $(OBJ) $(LIBHNJ)/libhnj.a
 install:
 	$(INSTALL) -c nroff $(ROOT)$(BINDIR)/nroff
 	$(STRIP) $(ROOT)$(BINDIR)/nroff
-	$(INSTALL) -c -m 644 nroff.1b $(ROOT)$(MANDIR)/man1b/nroff.1b
+	$(INSTALL) -c -m 644 nroff.1 $(ROOT)$(MANDIR)/man1/nroff.1
 
 clean:
 	rm -f $(OBJ) nroff core log *~

--- a/troff/nroff.d/nroff.1
+++ b/troff/nroff.d/nroff.1
@@ -32,14 +32,14 @@
 .\" WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 .\" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.TH NROFF 1B "9/4/06" "Heirloom Documentation Tools" "BSD System Compatibility"
+.TH NROFF 1 "9/4/06" "Heirloom Documentation Tools" "BSD System Compatibility"
 .SH NAME
-nroff \- (BSD) format documents for display or line-printer
+nroff \- format documents for display or line-printer
 .SH SYNOPSIS
 .HP
 .ad l
 .nh
-\fB/usr/ucb/nroff\fR
+\fBnroff\fR
 [\fB\-ehiqzV\fR]
 [\fB\-d\fIaS\fR]
 [\fB\-d\fIa\fB=\fIS\fR]
@@ -266,6 +266,6 @@ B. W. Kernighan,
 .I
 A TROFF Tutorial
 .br
-eqn(1B), tbl(1B)
+eqn(1), tbl(1)
 .br
 col(1)

--- a/troff/troff.d/Makefile.mk
+++ b/troff/troff.d/Makefile.mk
@@ -29,7 +29,7 @@ install:
 	$(STRIP) $(ROOT)$(BINDIR)/ta
 	$(INSTALL) -c otfdump $(ROOT)$(BINDIR)/otfdump
 	$(STRIP) $(ROOT)$(BINDIR)/otfdump
-	$(INSTALL) -c -m 644 troff.1b $(ROOT)$(MANDIR)/man1b/troff.1b
+	$(INSTALL) -c -m 644 troff.1 $(ROOT)$(MANDIR)/man1/troff.1
 	$(INSTALL) -c -m 644 otfdump.1 $(ROOT)$(MANDIR)/man1/otfdump.1
 
 clean:

--- a/troff/troff.d/dpost.d/dpost.1
+++ b/troff/troff.d/dpost.d/dpost.1
@@ -31,7 +31,7 @@ dpost \- troff postprocessor for PostScript printers
 .HP
 .ad l
 .nh
-\fB/usr/ucb/dpost\fR
+\fBdpost\fR
 [\fB\-c\fR\ \fInum\fR]
 [\fB\-e\fR\ \fInum\fR]
 [\fB\-m\fR\ \fInum\fR]
@@ -52,7 +52,7 @@ dpost \- troff postprocessor for PostScript printers
 .hy 1
 .SH DESCRIPTION
 \fIdpost\fR translates \fIfiles\fR created by 
-\fItroff\fR(1B)
+\fItroff\fR(1)
 into PostScript and writes the results on the standard output.
 If no
 \fIfiles\fR are specified, or if \- is one of the input \fIfiles\fR,
@@ -226,7 +226,7 @@ user coordinate system.
 .br
 /usr/ucblib/doctools/tmac/color
 .SH SEE ALSO
-troff(1B)
+troff(1)
 .SH DIAGNOSTICS
 The following exit values are returned:
 .TP 10

--- a/troff/troff.d/otfdump.1
+++ b/troff/troff.d/otfdump.1
@@ -7,7 +7,7 @@ otfdump \- dump the contents of OpenType font files
 .HP
 .ad l
 .nh
-\fB/usr/ucb/otfdump\fR
+\fBotfdump\fR
 [\fB\-ckns\fR]
 font ...
 .br
@@ -40,4 +40,4 @@ in the format `\fBname \fIstring\fR'.
 prints only the substitution features available with the font,
 in the format `\fBfeature \fIstring \fBsubstitution \fIstring1 string2\fR'.
 .SH "SEE ALSO"
-troff(1B)
+troff(1)

--- a/troff/troff.d/tmac.d/mcolor.7
+++ b/troff/troff.d/tmac.d/mcolor.7
@@ -106,7 +106,7 @@ dictionary in file
 .br
 .B \*(dP/color.ps
 .SH SEE ALSO
-.BR troff (1B),
+.BR troff (1),
 .BR dpost (1)
 .SH NOTES
 Use of the

--- a/troff/troff.d/tmac.d/mpictures.7
+++ b/troff/troff.d/tmac.d/mpictures.7
@@ -21,7 +21,7 @@ mpictures \- picture inclusion macros
 .SH DESCRIPTION
 .I Mpictures
 macros insert PostScript pictures into
-.IR troff (1B)
+.IR troff (1)
 documents.
 The macros are:
 .TP
@@ -166,7 +166,7 @@ comment for further processing, as in
 .fi
 .RE
 .SH SEE ALSO
-.IR troff (1B)
+.IR troff (1)
 .SH DIAGNOSTICS
 A picture file that can't be read by the PostScript
 postprocessor is replaced by white space.

--- a/troff/troff.d/troff.1
+++ b/troff/troff.d/troff.1
@@ -32,14 +32,14 @@
 .\" WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 .\" OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 .\" EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-.TH TROFF 1B "9/4/06" "Heirloom Documentation Tools" "BSD System Compatibility"
+.TH TROFF 1 "9/4/06" "Heirloom Documentation Tools" "BSD System Compatibility"
 .SH NAME
-troff \- (BSD) typeset or format documents
+troff \- typeset or format documents
 .SH SYNOPSIS
 .HP
 .ad l
 .nh
-\fB/usr/ucb/troff\fR
+\fBtroff\fR
 [\fB\-af\&izV\fR]
 [\fB\-d\fIaS\fR]
 [\fB\-d\fIa\fB=\fIS\fR]
@@ -297,4 +297,4 @@ B. W. Kernighan,
 .I
 A TROFF Tutorial
 .br
-eqn(1B), tbl(1B)
+eqn(1), tbl(1)

--- a/vgrind/Makefile.mk
+++ b/vgrind/Makefile.mk
@@ -26,7 +26,7 @@ install:
 	$(INSTALL) -c vfontedpr $(ROOT)$(LIBDIR)/vfontedpr
 	$(STRIP) $(ROOT)$(LIBDIR)/vfontedpr
 	$(INSTALL) -c -m 644 vgrindefs.src $(ROOT)$(LIBDIR)/vgrindefs
-	$(INSTALL) -c -m 644 vgrind.1b $(ROOT)$(MANDIR)/man1b/vgrind.1b
+	$(INSTALL) -c -m 644 vgrind.1 $(ROOT)$(MANDIR)/man1/vgrind.1
 
 clean:
 	rm -f $(OBJ) vfontedpr vgrind retest retest.o core log *~

--- a/vgrind/vgrind.1
+++ b/vgrind/vgrind.1
@@ -42,15 +42,15 @@
 .\"
 .\" Sccsid @(#)vgrind.1b	1.3 (gritter) 11/6/05
 .\"
-.TH VGRIND 1B "11/6/05" "Heirloom Documentation Tools" "BSD System Compatibility"
+.TH VGRIND 1 "11/6/05" "Heirloom Documentation Tools" "BSD System Compatibility"
 .UC 4
 .SH NAME
-vgrind \- (BSD) grind nice listings of programs
+vgrind \- grind nice listings of programs
 .SH SYNOPSIS
 .HP
 .ad l
 .nh
-\fB/usr/ucb/vgrind\fR
+\fBvgrind\fR
 [\fB\-2ftnxw\fR]
 [\fB\-s\fIn\fR]
 [\fB\-h\ \fIheader\fR]
@@ -67,7 +67,7 @@ vgrind \- (BSD) grind nice listings of programs
 .I Vgrind
 formats the program sources which are arguments 
 in a nice style using
-.IR troff (1B).
+.IR troff (1).
 Comments are placed in italics, keywords in bold face,
 and the name of the current function is listed down the margin of each
 page as it is encountered.
@@ -76,7 +76,7 @@ page as it is encountered.
 runs in two basic modes, filter mode or regular mode.  In filter mode 
 .I vgrind
 acts as a filter in a manner similar to
-.IR tbl (1B).
+.IR tbl (1).
 The standard input is passed directly to the standard output except
 for lines bracketed by the 
 .I troff-like
@@ -90,14 +90,14 @@ These lines are formatted as described above.  The output from this
 filter can be passed to 
 .I troff 
 for output.  There need be no particular ordering with 
-.IR eqn (1B)
+.IR eqn (1)
 or
-.IR tbl (1B).
+.IR tbl (1).
 .PP
 In regular mode 
 .I vgrind
 accepts input files, processes them, and passes them to 
-.IR troff (1B)
+.IR troff (1)
 for output.  
 .PP
 In both modes 
@@ -185,7 +185,7 @@ index	file where source for index is created
 .br
 /usr/ucblib/vgrindefs	language descriptions
 .SH SEE ALSO
-troff(1B)
+troff(1)
 .SH NOTES
 Vfontedpr assumes that a certain programming style is followed:
 .PP


### PR DESCRIPTION
There's not really a need to distinguish these in the doctools package.
- rename *.[17]b to *.[17]
- install manpages to man[17] instead of man[17]b
- remove “(BSD)” and “/usr/ucb” from NAME and SYNOPSIS sections
- replace references to foo(1B) and foo(7B) with foo(1) and foo(7)
