### PR TITLE
Accept fonts with spaces in glyph names

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+2016-08-20
+    dpost generates valid PostScript when using fonts
+    with spaces in the glyph names.
+
 2016-04-27
     -mdoc: Table of contents with hyperlinks and PDF bookmarks
     added.

--- a/troff/troff.d/afm.h
+++ b/troff/troff.d/afm.h
@@ -139,6 +139,7 @@ extern	char	*afmdecodepath(const char *);
 #include <stdio.h>
 extern	int	otfcff(const char *, char *, size_t, size_t *, size_t *);
 extern	int	otft42(char *, char *, char *, size_t, FILE *);
+extern	int	fprintenc(FILE *, const char *);
 #endif
 
 extern struct dev	dev;

--- a/troff/troff.d/dpost.d/dpost.c
+++ b/troff/troff.d/dpost.d/dpost.c
@@ -3170,7 +3170,7 @@ printencvector(struct afmtab *a)
 		k < a->nchars &&
 		a->nametab[k] != NULL) {
 	    encmap[s - 128 + 32] = j;
-	    col += fprintf(gf, "/%s", a->nametab[k]);
+	    col += fprintenc(gf, a->nametab[k]);
 	    printencsep(&col);
 	    s++;
 	} else {
@@ -3183,7 +3183,7 @@ printencvector(struct afmtab *a)
     for (i = 1; i < a->nchars + 128 - 32 + nchtab && i < 256 - 32; i++) {
 	if (i < 128 - 32 && (k = a->fitab[i]) != 0 && k < a->nchars &&
 		a->nametab[k] != NULL) {
-	    col += fprintf(gf, "/%s", a->nametab[k]);
+	    col += fprintenc(gf, a->nametab[k]);
 	    printencsep(&col);
 	} else {
 	    while (s < a->nchars + 128 - 32 + nchtab &&
@@ -3195,7 +3195,7 @@ printencvector(struct afmtab *a)
 			k < a->nchars &&
 			a->nametab[k] != NULL) {
 		encmap[s - 128 + 32] = i + 32;
-		col += fprintf(gf, "/%s", a->nametab[k]);
+		col += fprintenc(gf, a->nametab[k]);
 		printencsep(&col);
 		s++;
 	    } else {
@@ -3219,7 +3219,7 @@ printencvector(struct afmtab *a)
 		    k < a->nchars &&
 		    a->nametab[k] != NULL) {
 	        encmap[s - 128 + 32] = i | n << 8;
-	        col += fprintf(gf, "/%s", a->nametab[k]);
+	        col += fprintenc(gf, a->nametab[k]);
 	        printencsep(&col);
 	        s++;
 	    } else {

--- a/troff/troff.d/otf.c
+++ b/troff/troff.d/otf.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <ctype.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdlib.h>
@@ -2510,6 +2511,18 @@ GID2SID(int gid)
 	return getSID(gid2sid[gid]);
 }
 
+int
+fprintenc(FILE *fd, const char *enc)
+{
+	const char *cp;
+	for (cp = enc; *cp && !isspace(*cp); cp++);
+	if (*cp) {
+		return fprintf(fd, "(%s) cvn", enc);
+	} else {
+		return fprintf(fd, "/%s", enc);
+	}
+}
+
 #ifndef	DPOST
 static int	ScriptList;
 static int	FeatureList;
@@ -3488,9 +3501,10 @@ otft42(char *font, char *path, char *_contents, size_t _size, FILE *fp)
 		fprintf(fp, "/CharStrings %d dict dup begin\n", nc);
 		for (i = 0; i < nc; i++) {
 			if ((cp = GID2SID(i)) != NULL &&
-					(i == 0 || strcmp(cp, ".notdef")))
-				fprintf(fp, "/%s %d def\n", cp, i);
-			else
+					(i == 0 || strcmp(cp, ".notdef"))) {
+				fprintenc(fp, cp);
+				fprintf(fp, " %d def\n", i);
+			} else
 				fprintf(fp, "/index0x%02X %d def\n", i, i);
 		}
 		fprintf(fp, "end readonly def\n");


### PR DESCRIPTION
Glyph names containing spaces should not cause PostScript
errors.

Fixes https://github.com/n-t-roff/heirloom-doctools/issues/33