### PR TITLE
eqn: Makefile dependencies fix

### DIFF
--- a/eqn/eqn.d/Makefile.mk
+++ b/eqn/eqn.d/Makefile.mk
@@ -37,23 +37,23 @@ eqnchar.7: eqnchar.7.in
 	sed 's"/usr/pub/"$(ROOT)$(PUBDIR)/"' eqnchar.7.in > $@
 
 diacrit.o: ../diacrit.c ../e.h y.tab.h
-eqnbox.o: ../eqnbox.c ../e.h
-font.o: ../font.c ../e.h
-fromto.o: ../fromto.c ../e.h
+eqnbox.o: ../eqnbox.c ../e.h y.tab.h
+font.o: ../font.c ../e.h y.tab.h
+fromto.o: ../fromto.c ../e.h y.tab.h
 funny.o: ../funny.c ../e.h y.tab.h
 glob.o: ../glob.c ../e.h
 integral.o: ../integral.c ../e.h y.tab.h
 io.o: ../io.c ../e.h
 lex.o: ../lex.c ../e.h y.tab.h
 lookup.o: ../lookup.c ../e.h y.tab.h
-mark.o: ../mark.c ../e.h
-matrix.o: ../matrix.c ../e.h
+mark.o: ../mark.c ../e.h y.tab.h
+matrix.o: ../matrix.c ../e.h y.tab.h
 move.o: ../move.c ../e.h y.tab.h
-over.o: ../over.c ../e.h
-paren.o: ../paren.c ../e.h
-pile.o: ../pile.c ../e.h
+over.o: ../over.c ../e.h y.tab.h
+paren.o: ../paren.c ../e.h y.tab.h
+pile.o: ../pile.c ../e.h y.tab.h
 shift.o: ../shift.c ../e.h y.tab.h
-size.o: ../size.c ../e.h
-sqrt.o: ../sqrt.c ../e.h
+size.o: ../size.c ../e.h y.tab.h
+sqrt.o: ../sqrt.c ../e.h y.tab.h
 text.o: ../text.c ../e.h y.tab.h
 e.o: e.c ../e.h

--- a/eqn/neqn.d/Makefile.mk
+++ b/eqn/neqn.d/Makefile.mk
@@ -31,23 +31,23 @@ clean:
 mrproper: clean
 
 diacrit.o: ../diacrit.c ../e.h y.tab.h
-eqnbox.o: ../eqnbox.c ../e.h
-font.o: ../font.c ../e.h
-fromto.o: ../fromto.c ../e.h
+eqnbox.o: ../eqnbox.c ../e.h y.tab.h
+font.o: ../font.c ../e.h y.tab.h
+fromto.o: ../fromto.c ../e.h y.tab.h
 funny.o: ../funny.c ../e.h y.tab.h
 glob.o: ../glob.c ../e.h
 integral.o: ../integral.c ../e.h y.tab.h
 io.o: ../io.c ../e.h
 lex.o: ../lex.c ../e.h y.tab.h
 lookup.o: ../lookup.c ../e.h y.tab.h
-mark.o: ../mark.c ../e.h
-matrix.o: ../matrix.c ../e.h
+mark.o: ../mark.c ../e.h y.tab.h
+matrix.o: ../matrix.c ../e.h y.tab.h
 move.o: ../move.c ../e.h y.tab.h
-over.o: ../over.c ../e.h
-paren.o: ../paren.c ../e.h
-pile.o: ../pile.c ../e.h
+over.o: ../over.c ../e.h y.tab.h
+paren.o: ../paren.c ../e.h y.tab.h
+pile.o: ../pile.c ../e.h y.tab.h
 shift.o: ../shift.c ../e.h y.tab.h
-size.o: ../size.c ../e.h
-sqrt.o: ../sqrt.c ../e.h
+size.o: ../size.c ../e.h y.tab.h
+sqrt.o: ../sqrt.c ../e.h y.tab.h
 text.o: ../text.c ../e.h y.tab.h
 e.o: e.c ../e.h


### PR DESCRIPTION
I can also change the syntax to the IMHO more legible:

a.o b.o ... : y.tab.h