### PR TITLE
refer: Fix a/b/c indices

### DIFF
--- a/refer/hunt2.c
+++ b/refer/hunt2.c
@@ -280,13 +280,15 @@ doquery(long *hpt, int nhash, FILE *fb, int nitem, char **qitem, unsigned *mptr)
 long
 getl(FILE *fb)
 {
-	return(getw(fb));
+	long ll;
+	fread(&ll, sizeof(ll), 1, fb);
+	return ll;
 }
 
 void
 putl(long ll, FILE *f)
 {
-	putw(ll, f);
+	fwrite(&ll, sizeof(ll), 1, f);
 }
 
 int

--- a/refer/inv6.c
+++ b/refer/inv6.c
@@ -92,11 +92,13 @@ whash(FILE *ft, FILE *fa, FILE *fb, int nhash, int _iflong, long *ptotct, int *p
 void
 putl(long ll, FILE *f)
 {
-	putw(ll, f);
+	fwrite(&ll, sizeof(ll), 1, f);
 }
 
 long
 getl(FILE *f)
 {
-	return(getw(f));
+	long ll;
+	fread(&ll, sizeof(ll), 1, f);
+	return ll;
 }


### PR DESCRIPTION
refer with .i{a,b,c} indices breaks on x86_64 Linux, where sizeof(long)
is greater than sizeof(int). This breaks putl/getl: They use putw/getw
internally, which are aliased to putc/getc. putc/getc take int rather
than long as the code expects. However, the functions are used by
putl/getl for long instead of int.