### PR TITLE
Fixes for debugging refer

### DIFF
--- a/refer/deliv2.c
+++ b/refer/deliv2.c
@@ -62,10 +62,10 @@ mindex(const char *s, int c)
 void *
 zalloc(int m,int n)
 {
-	void *
 # if D1
 	fprintf(stderr, "calling calloc for %d*%d bytes\n",m,n);
 # endif
+	void *
 	t = calloc(m,n);
 # if D1
 	fprintf(stderr, "calloc returned %p\n", t);

--- a/refer/hunt3.c
+++ b/refer/hunt3.c
@@ -32,10 +32,10 @@ getq(char **v)
 	static int eof = 0;
 	extern char *sinput;
 	char *p;
-	int c, n = 0, las = 0;
+	int c, n = 0, las = 0, use_sinput = (sinput!=NULL);
 	if (eof) return(-1);
 	p = buff;
-	while ( (c = (sinput ? *sinput++ : getchar()) ) > 0)
+	while ( (c = (use_sinput ? *sinput++ : getchar()) ) > 0)
 	{
 		if (c== '\n')
 			break;
@@ -60,7 +60,7 @@ getq(char **v)
 	if (p > buff + BSIZ)
 		fprintf(stderr, "query long than %d characters\n", BSIZ);
 	assert(p < buff + BSIZ);
-	if (sinput==0 && c<= 0) eof=1;
+	if (use_sinput || c<=0) eof=1;
 # if D1
 	fprintf(stderr, "no. keys %d\n",n);
 	for(c=0; c<n; c++)

--- a/refer/hunt7.c
+++ b/refer/hunt7.c
@@ -74,7 +74,7 @@ findline(char *_in, char **out, int outlen, long _indexdate)
 	fprintf(stderr, "lp %ld llen %ld\n",lp, llen);
 # endif
 # ifdef D1
-	fprintf(stderr, "fa now %o, p %o in %o %s\n",fa, p,in,_in);
+	fprintf(stderr, "fa now %o, p %o %s\n",fa, p,_in);
 # endif
 	if (nofil)
 	{


### PR DESCRIPTION
I put the cart before the horse with the previous pull request. This should help with debugging `refer` in case it breaks again in the future.