### PR TITLE
Avoid UB in hash() for refer

### DIFF
--- a/refer/deliv2.c
+++ b/refer/deliv2.c
@@ -31,10 +31,12 @@
 int
 hash (const char *s)
 {
-	int c, n;
+	unsigned int c, n;
+	int r;
 	for(n=0; (c= *s); s++)
-		n += (c*n+ (c << (unsigned)n%4));
-	return(n>0 ? n : -n);
+		n += (c*n+ (c << n%4));
+	r = (int)n;
+	return(r>0 ? r : -r);
 }
 
 void


### PR DESCRIPTION
Found by `clang -fsanitize=undefined`.

It also found an issue with the `struct Font *` cast in `ptinit()` in `t10.c`. I assume that's already known, going by the description of commit 7cf07f4c5d5af63f1987ad614d24b5c75dcf4b01. I most likely won't touch that one; it seems to require quite extensive knowledge of the internals of the font system to even make sense of that cast. I expect the cast may cause a crash on architectures that are strict about aligned access, though.