### PR TITLE
Fix `.substring` out-of-bounds index which can cause segfault

### DIFF
--- a/troff/n3.c
+++ b/troff/n3.c
@@ -1819,7 +1819,7 @@ casesubstring(void)
 				n1 = n2;
 				n2 = j;
 			}
-			for (j = 0; j <= k; j++) {
+			for (j = 0; j < k; j++) {
 				if (st == 0) {
 					if (j >= n1)
 						st = 1;


### PR DESCRIPTION
If `.substring` stop index is beyond the end of the string, the loop iterating to obtain the substring seems to process one extra character. Depending on various circumstances, this can have either:
- no effect
- wrong text output
- segmentation fault

The following test document, when repeated multiple times, on my computer produces all of these 3 outcomes.

```
.do xflag 3
.mediasize 100p 100p
.lc_ctype ro_RO.UTF-8
.fp 1 R texgyreschola-regular otf
.po 10p
.ll 40p
.ds S abcd
.substring S 1 100
\*S
.substring S 1 100
\*S
.br
```

Expected output: "bcd cd".

P.S. Is just a pull request OK, or should it be accompanied with an open issue?