### PR TITLE
Fix build with GCC 10.

### DIFF
--- a/troff/n5.c
+++ b/troff/n5.c
@@ -1588,8 +1588,6 @@ caseie(void)
 	caseif(1);
 }
 
-int	tryglf;
-
 void
 caseif(int x)
 {


### PR DESCRIPTION
The variable tryglf is defined twice. With gcc -fcommon, the default up
to GCC 9, the duplicate definition is silently accepted. With gcc
-fno-common, the default as of GCC 10, the duplicate definition is
rejected. Remove one of the definitions.