### PR TITLE
Fix drawspline() to handle more than 97 points properly.

### DIFF
--- a/troff/troff.d/dpost.d/draw.c
+++ b/troff/troff.d/dpost.d/draw.c
@@ -397,8 +397,8 @@ drawspline(
  *
  */
 
-
-    for ( N = 2; N < sizeof(x)/sizeof(x[0]); N++ )
+again:
+    for ( N = 2; N < sizeof(x)/sizeof(x[0])-1; N++ )
 	if (fscanf(fp, "%d %d", &x[N], &y[N]) != 2)
 		break;
 
@@ -418,6 +418,9 @@ drawspline(
 
     hgoto(x[N]);			/* where troff expects to be */
     vgoto(y[N]);
+
+    if ( N >= sizeof(x)/sizeof(x[0])-1 )
+	goto again;
 
     resetpos();				/* not sure where the printer is */
 


### PR DESCRIPTION
I hit a problem dpost exits with an error like the followings:

    dpost: unknown input character 55 - (line 172)

The given data has many arguments for D~ (draw spline).  drawspline() seems to limited to 97 of (x, y) pairs at maximum.  The diff is to remove the limit.