### PR TITLE
Fix the placement of bracket construction pieces in PDF

### DIFF
--- a/troff/troff.d/postscript/dpost.ps
+++ b/troff/troff.d/postscript/dpost.ps
@@ -217,12 +217,6 @@
 
 /Sdefs [
 	/underscore		[0 0 500 0]
-	/bracketlefttp		[208 500]
-	/bracketleftbt		[208 500]
-	/bracketrighttp		[-60 380]
-	/bracketrightbt		[-60 380]
-	/braceleftbt		[209 490]
-	/bracketrightex		[220 -125 500 0]
 	/radical		[0 0 550 0]
 	% NeWSprint's \(br is too low, compensate
 	statusdict /product get (NeWS Server) eq {
@@ -231,7 +225,6 @@
 
 	} {
 		/radicalex		[-50 0 500.001 0]
-		/parenleftex		[-20 -170 0 0]
 	} ifelse
 	/integral		[100 -50 500 0]
 	/infinity		[10 -75 730 0]


### PR DESCRIPTION
The proposed commit removes PostScript definitions that alter the positions of bracket construction symbols in the `\[bracket*]`, `\[brace*]` and `\[paren*]` groups.  The alternations produce disconnection in the PDFs generated with ghostscript, though the original PostScript output looks fine.

For example, the input

```
.nr PS 26
.PP
\b'\[bracketlefttp]\[bracketleftex]'\~
\b'\[bracketrighttp]\[bracketrightex]'\~
\b'\[bracelefttp]\[braceleftmid]'\~
\b'\[bracerighttp]\[bracerightmid]'\~
\b'\[parenlefttp]\[parenleftex]'\~
\b'\[parenrighttp]\[parenrightex]'\~
.br
.sp 8v
.PP
\b'\[bracketlefttp]\[bracketleftex]\[bracketleftbt]'\~
\b'\[bracketrighttp]\[bracketrightex]\[bracketrightbt]'\~
\b'\[bracelefttp]\[braceleftmid]\[braceleftbt]'\~
\b'\[bracerighttp]\[bracerightmid]\[bracerightbt]'\~
\b'\[parenlefttp]\[parenleftex]\[parenleftbt]'\~
\b'\[parenrighttp]\[parenrightex]\[parenrightbt]'\~
```

looks like that in PDF document generated with `ps2pdf`:

![before-pdf](https://github.com/n-t-roff/heirloom-doctools/assets/72668865/850e2fea-0b45-4cde-b2a8-b497e5a4b1fc)


 After the commit, the pieces connect correctly both in PostScript and in PDF:

![pdf-after](https://github.com/n-t-roff/heirloom-doctools/assets/72668865/2095a484-8075-492e-9905-01659707816e)

EDIT: since the changed file is treated as a binary, the diff is as follows:

```
--- a/troff/troff.d/postscript/dpost.ps
+++ b/troff/troff.d/postscript/dpost.ps
@@ -217,12 +217,6 @@

 /Sdefs [
        /underscore             [0 0 500 0]
-       /bracketlefttp          [208 500]
-       /bracketleftbt          [208 500]
-       /bracketrighttp         [-60 380]
-       /bracketrightbt         [-60 380]
-       /braceleftbt            [209 490]
-       /bracketrightex         [220 -125 500 0]
        /radical                [0 0 550 0]
        % NeWSprint's \(br is too low, compensate
        statusdict /product get (NeWS Server) eq {
@@ -231,7 +225,6 @@

        } {
                /radicalex              [-50 0 500.001 0]
-               /parenleftex            [-20 -170 0 0]
        } ifelse
        /integral               [100 -50 500 0]
        /infinity               [10 -75 730 0]
```